### PR TITLE
Fix unreliable gun hits detection

### DIFF
--- a/Mirage-2000/Nasal/weapons.nas
+++ b/Mirage-2000/Nasal/weapons.nas
@@ -181,11 +181,9 @@ var findmultiplayer = func(targetCoord, dist = 20) {
         
         if((type == "multiplayer" or type == "tanker" or type == "aircraft") and HavePosition != nil and targetCoord != nil and name != nil)
         {
-            var elev = HavePosition.getNode("altitude-m", 1).getValue();
             var lat = HavePosition.getNode("latitude-deg", 1).getValue();
             var lon = HavePosition.getNode("longitude-deg", 1).getValue();
-            
-            elev = (elev == nil) ? HavePosition.getNode("altitude-ft", 1).getValue() * FT2M : elev;
+            var elev = HavePosition.getNode("altitude-ft", 1).getValue() * FT2M;
             
             #print("name:"~name.getValue());
             #print("lat"~ lat.getValue()~" lon:"~ lon.getValue()~ "elev:"~ elev.getValue());


### PR DESCRIPTION
Sometimes, gun hits were not reported whatsoever.
I found this problem when adapting the code to the Viggen, and some user reported the same issue.

The issue seems to be that `position/altitude-m` in AI models is unreliable (in fact I am not sure where it comes from). The issue would occur if a 'zombie' value remained in `altitude-m`. It should not be a problem with `altitude-ft`, which is set directly by Flightgear.